### PR TITLE
Containerisation refactored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
-FROM node:10
+# Use alpine node version
+FROM node:10.15.3-alpine
 
-# Create app directory
-WORKDIR /usr/local
+# Create working directory and set node user as owner
+WORKDIR /usr/src/app
+RUN chown node:node /usr/src/app
+
+# Switch to node user
+USER node
 
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
-COPY package*.json ./
-
+COPY --chown=node:node package*.json ./
 RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
 
-RUN selenium-standalone start
+# Bundle app source setting node user as owner
+COPY --chown=node:node . .
 
-EXPOSE 4444
+CMD yarn run wdio

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,14 +6,8 @@ services:
     container_name: wdio-cucumber
     links:
       - selenium
-    volumes:
-      - node_modules:/usr/src/app/node_modules/
-      - .:/usr/src/app
 
   selenium:
     image: selenium/standalone-chrome
     expose:
       - "4444"
-
-volumes:
-  node_modules: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  wdio-cucumber:
+    build: .
+    image: wdio-cucumber
+    container_name: wdio-cucumber
+    links:
+      - selenium
+    volumes:
+      - node_modules:/usr/src/app/node_modules/
+      - .:/usr/src/app
+
+  selenium:
+    image: selenium/standalone-chrome
+    expose:
+      - "4444"
+
+volumes:
+  node_modules: {}

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,4 +1,5 @@
 exports.config = {
+    hostname: 'selenium',
     //
     // ==================
     // Specify Test Files


### PR DESCRIPTION
# Contribution description
Dockerfile updated to containerise acceptance tests.  Docker-compose added to allow selenium standalone to run in a separate container within the same network.

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [ ] Contributed code passes the unit tests
- [ ] Added rules are described in the [readme file](README.md)
- [x] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
